### PR TITLE
Add ESP32-CAM Arduino example

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,7 @@ python - redis, bff, ansible
 
 
 CMD : docker build -t <your style name> -f Dockerfile ..
+
+## Arduino ESP32-CAM Example
+
+This repository now includes a simple sketch for the ESP32-CAM board. You can find it under `arduino/esp32cam/esp32cam_example.ino`. Update the WiFi credentials in the sketch and upload it using the Arduino IDE to capture frames and print information about them over the serial monitor.

--- a/arduino/esp32cam/esp32cam_example.ino
+++ b/arduino/esp32cam/esp32cam_example.ino
@@ -1,0 +1,40 @@
+#include <Arduino.h>
+#include <esp32cam.h>
+#include <WiFi.h>
+
+const char* WIFI_SSID = "your_wifi_ssid";
+const char* WIFI_PASS = "your_wifi_password";
+
+void setup() {
+  Serial.begin(115200);
+
+  auto cfg = esp32cam::Camera::config();
+  cfg.setPins(esp32cam::pins::AiThinker);
+  cfg.setResolution(esp32cam::Resolution::find(640, 480));
+  cfg.setBufferCount(1);
+
+  if (!esp32cam::Camera.begin(cfg)) {
+    Serial.println("Camera init failed");
+    return;
+  }
+
+  WiFi.begin(WIFI_SSID, WIFI_PASS);
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+    Serial.print(".");
+  }
+  Serial.println();
+  Serial.print("Connected! IP address: ");
+  Serial.println(WiFi.localIP());
+}
+
+void loop() {
+  auto frame = esp32cam::capture();
+  if (frame) {
+    Serial.printf("Captured frame: %dx%d, %d bytes\n", frame->getWidth(), frame->getHeight(), frame->size());
+    frame->release();
+  } else {
+    Serial.println("Capture failed");
+  }
+  delay(5000);
+}


### PR DESCRIPTION
## Summary
- add `arduino/esp32cam/esp32cam_example.ino` showing how to capture frames with ESP32-CAM
- document new example in README

## Testing
- `pytest -q`
- `bash mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68405cb41844832fbf1064e7c1b98b15