### PR TITLE
Add ESP32-CAM example in C

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,12 @@ python - redis, bff, ansible
 
 
 CMD : docker build -t <your style name> -f Dockerfile ..
+
+## Arduino ESP32-CAM Example
+
+This repository now includes sample code for the ESP32‑CAM board.
+
+* `arduino/esp32cam/esp32cam_example.ino` — An Arduino sketch written in C++.
+* `arduino/esp32cam_c/esp32cam_c_example.c` — A C example that targets the ESP‑IDF environment.
+
+Update the WiFi credentials (if applicable) and upload/build using your preferred toolchain to capture frames and print information about them over the serial monitor.

--- a/arduino/esp32cam/esp32cam_example.ino
+++ b/arduino/esp32cam/esp32cam_example.ino
@@ -1,0 +1,40 @@
+#include <Arduino.h>
+#include <esp32cam.h>
+#include <WiFi.h>
+
+const char* WIFI_SSID = "your_wifi_ssid";
+const char* WIFI_PASS = "your_wifi_password";
+
+void setup() {
+  Serial.begin(115200);
+
+  auto cfg = esp32cam::Camera::config();
+  cfg.setPins(esp32cam::pins::AiThinker);
+  cfg.setResolution(esp32cam::Resolution::find(640, 480));
+  cfg.setBufferCount(1);
+
+  if (!esp32cam::Camera.begin(cfg)) {
+    Serial.println("Camera init failed");
+    return;
+  }
+
+  WiFi.begin(WIFI_SSID, WIFI_PASS);
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+    Serial.print(".");
+  }
+  Serial.println();
+  Serial.print("Connected! IP address: ");
+  Serial.println(WiFi.localIP());
+}
+
+void loop() {
+  auto frame = esp32cam::capture();
+  if (frame) {
+    Serial.printf("Captured frame: %dx%d, %d bytes\n", frame->getWidth(), frame->getHeight(), frame->size());
+    frame->release();
+  } else {
+    Serial.println("Capture failed");
+  }
+  delay(5000);
+}

--- a/arduino/esp32cam_c/esp32cam_c_example.c
+++ b/arduino/esp32cam_c/esp32cam_c_example.c
@@ -1,0 +1,59 @@
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "esp_camera.h"
+#include "esp_log.h"
+#include "nvs_flash.h"
+
+static const char *TAG = "esp32cam_c";
+
+void app_main(void)
+{
+    esp_err_t err = nvs_flash_init();
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "NVS init failed: %s", esp_err_to_name(err));
+        return;
+    }
+
+    camera_config_t config = {
+        .pin_pwdn  = 32,
+        .pin_reset = -1,
+        .pin_xclk = 0,
+        .pin_sscb_sda = 26,
+        .pin_sscb_scl = 27,
+        .pin_d7 = 35,
+        .pin_d6 = 34,
+        .pin_d5 = 39,
+        .pin_d4 = 36,
+        .pin_d3 = 21,
+        .pin_d2 = 19,
+        .pin_d1 = 18,
+        .pin_d0 = 5,
+        .pin_vsync = 25,
+        .pin_href = 23,
+        .pin_pclk = 22,
+        .xclk_freq_hz = 20000000,
+        .ledc_timer = LEDC_TIMER_0,
+        .ledc_channel = LEDC_CHANNEL_0,
+        .pixel_format = PIXFORMAT_JPEG,
+        .frame_size = FRAMESIZE_VGA,
+        .jpeg_quality = 10,
+        .fb_count = 1
+    };
+
+    err = esp_camera_init(&config);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Camera init failed: %s", esp_err_to_name(err));
+        return;
+    }
+
+    while (1) {
+        camera_fb_t *frame = esp_camera_fb_get();
+        if (!frame) {
+            ESP_LOGE(TAG, "Capture failed");
+        } else {
+            ESP_LOGI(TAG, "Captured frame: %dx%d, %d bytes", frame->width, frame->height, frame->len);
+            esp_camera_fb_return(frame);
+        }
+        vTaskDelay(pdMS_TO_TICKS(5000));
+    }
+}


### PR DESCRIPTION
## Summary
- add a new ESP32-CAM example written in C for the ESP-IDF environment
- document both the C and C++ examples in the README

## Testing
- `pytest -q` *(no tests discovered)*

------
https://chatgpt.com/codex/tasks/task_e_68405cb41844832fbf1064e7c1b98b15